### PR TITLE
chore: bump version to 1.4.1 and enhance project templates

### DIFF
--- a/cmd/gog/new/_template/README.md
+++ b/cmd/gog/new/_template/README.md
@@ -14,6 +14,7 @@
   </pre>
 </p>
 
+
 <p align="center">
   A powerful <a href="https://go.dev" target="_blank">Go</a> project scaffolding tool for generating production-ready service templates.
 </p>

--- a/cmd/gog/new/_template/docs/docs.go
+++ b/cmd/gog/new/_template/docs/docs.go
@@ -73,6 +73,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/ping": {
+            "get": {
+                "description": "Tests connectivity by pinging the application, requires authentication to verify caller identity",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Ping",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/posts": {
             "post": {
                 "description": "Create a new post with the provided data",
@@ -555,10 +584,10 @@ const docTemplate = `{
         }
     },
     "securityDefinitions": {
-        "Bearer": {
-            "description": "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
+        "ApiKey": {
+            "description": "API key for authentication",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-API-KEY",
             "in": "header"
         }
     }
@@ -567,11 +596,11 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:3000",
+	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},
 	Title:            "PROJECT_NAME",
-	Description:      "Your API Description",
+	Description:      "API for PROJECT_NAME",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/cmd/gog/new/_template/docs/swagger.json
+++ b/cmd/gog/new/_template/docs/swagger.json
@@ -1,12 +1,11 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Your API Description",
+        "description": "API for PROJECT_NAME",
         "title": "PROJECT_NAME",
         "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:3000",
     "basePath": "/api",
     "paths": {
         "/health": {
@@ -51,6 +50,35 @@
                     "health"
                 ],
                 "summary": "Readiness check",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ping": {
+            "get": {
+                "description": "Tests connectivity by pinging the application, requires authentication to verify caller identity",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Ping",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -549,10 +577,10 @@
         }
     },
     "securityDefinitions": {
-        "Bearer": {
-            "description": "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
+        "ApiKey": {
+            "description": "API key for authentication",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-API-KEY",
             "in": "header"
         }
     }

--- a/cmd/gog/new/_template/docs/swagger.yaml
+++ b/cmd/gog/new/_template/docs/swagger.yaml
@@ -114,10 +114,9 @@ definitions:
       updatedAt:
         type: string
     type: object
-host: localhost:3000
 info:
   contact: {}
-  description: Your API Description
+  description: API for PROJECT_NAME
   title: PROJECT_NAME
   version: "1.0"
 paths:
@@ -157,6 +156,26 @@ paths:
           schema:
             $ref: '#/definitions/health.HealthResponse'
       summary: Readiness check
+      tags:
+      - health
+  /ping:
+    get:
+      consumes:
+      - application/json
+      description: Tests connectivity by pinging the application, requires authentication
+        to verify caller identity
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/health.HealthResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/health.HealthResponse'
+      summary: Ping
       tags:
       - health
   /posts:
@@ -368,10 +387,9 @@ paths:
       tags:
       - users
 securityDefinitions:
-  Bearer:
-    description: 'JWT Authorization header using the Bearer scheme. Example: "Bearer
-      {token}"'
+  ApiKey:
+    description: API key for authentication
     in: header
-    name: Authorization
+    name: X-API-KEY
     type: apiKey
 swagger: "2.0"

--- a/cmd/gog/new/_template/internal/domains/health/handler.go
+++ b/cmd/gog/new/_template/internal/domains/health/handler.go
@@ -27,6 +27,7 @@ func NewHealthHandler(d healthHandlerDependencies) *HealthHandler {
 }
 
 func (h *HealthHandler) RegisterRoutes(r fiber.Router) {
+	r.Get("/ping", h.Ping)
 	r.Get("/health", h.HealthCheck)
 	r.Get("/health/ready", h.ReadinessCheck)
 }
@@ -75,6 +76,20 @@ func (h *HealthHandler) ReadinessCheck(c *fiber.Ctx) error {
 		})
 	}
 
+	return c.JSON(HealthResponse{
+		Status: "ok",
+	})
+}
+
+// @Summary      Ping
+// @Description  Tests connectivity by pinging the application, requires authentication to verify caller identity
+// @Tags         health
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  HealthResponse
+// @Failure      500  {object}  HealthResponse
+// @Router       /ping [get]
+func (h *HealthHandler) Ping(c *fiber.Ctx) error {
 	return c.JSON(HealthResponse{
 		Status: "ok",
 	})

--- a/cmd/gog/new/_template/justfile
+++ b/cmd/gog/new/_template/justfile
@@ -14,6 +14,8 @@ alias sw := swagger
 alias db := docker-build
 alias dr := docker-run
 alias dbr := docker-build-run
+alias gc := generate-creds
+alias rc := regenerate-creds
 
 # Serve the application
 serve:
@@ -56,5 +58,12 @@ docker-run:
 
 docker-build-run: docker-build docker-run
 
+generate-creds:
+    nsc generate creds --name PROJECT_NAME_user --account PROJECT_NAME_account --output-file secrets/PROJECT_NAME_user.creds
+
+regenerate-creds:
+    rm secrets/PROJECT_NAME_user.creds
+    nsc generate creds --name PROJECT_NAME_user --account PROJECT_NAME_account --output-file secrets/PROJECT_NAME_user.creds
+
 migrate-down:
-    go run . migrate down
+    go run . migrate down -c config.yaml

--- a/scaffold_source/docs/docs.go
+++ b/scaffold_source/docs/docs.go
@@ -73,6 +73,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/ping": {
+            "get": {
+                "description": "Tests connectivity by pinging the application, requires authentication to verify caller identity",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Ping",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/posts": {
             "post": {
                 "description": "Create a new post with the provided data",
@@ -555,10 +584,10 @@ const docTemplate = `{
         }
     },
     "securityDefinitions": {
-        "Bearer": {
-            "description": "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
+        "ApiKey": {
+            "description": "API key for authentication",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-API-KEY",
             "in": "header"
         }
     }
@@ -567,11 +596,11 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:3000",
+	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},
 	Title:            "PROJECT_NAME",
-	Description:      "Your API Description",
+	Description:      "API for PROJECT_NAME",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/scaffold_source/docs/swagger.json
+++ b/scaffold_source/docs/swagger.json
@@ -1,12 +1,11 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Your API Description",
+        "description": "API for PROJECT_NAME",
         "title": "PROJECT_NAME",
         "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:3000",
     "basePath": "/api",
     "paths": {
         "/health": {
@@ -51,6 +50,35 @@
                     "health"
                 ],
                 "summary": "Readiness check",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/health.HealthResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ping": {
+            "get": {
+                "description": "Tests connectivity by pinging the application, requires authentication to verify caller identity",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Ping",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -549,10 +577,10 @@
         }
     },
     "securityDefinitions": {
-        "Bearer": {
-            "description": "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
+        "ApiKey": {
+            "description": "API key for authentication",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-API-KEY",
             "in": "header"
         }
     }

--- a/scaffold_source/docs/swagger.yaml
+++ b/scaffold_source/docs/swagger.yaml
@@ -114,10 +114,9 @@ definitions:
       updatedAt:
         type: string
     type: object
-host: localhost:3000
 info:
   contact: {}
-  description: Your API Description
+  description: API for PROJECT_NAME
   title: PROJECT_NAME
   version: "1.0"
 paths:
@@ -157,6 +156,26 @@ paths:
           schema:
             $ref: '#/definitions/health.HealthResponse'
       summary: Readiness check
+      tags:
+      - health
+  /ping:
+    get:
+      consumes:
+      - application/json
+      description: Tests connectivity by pinging the application, requires authentication
+        to verify caller identity
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/health.HealthResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/health.HealthResponse'
+      summary: Ping
       tags:
       - health
   /posts:
@@ -368,10 +387,9 @@ paths:
       tags:
       - users
 securityDefinitions:
-  Bearer:
-    description: 'JWT Authorization header using the Bearer scheme. Example: "Bearer
-      {token}"'
+  ApiKey:
+    description: API key for authentication
     in: header
-    name: Authorization
+    name: X-API-KEY
     type: apiKey
 swagger: "2.0"

--- a/scaffold_source/internal/domains/health/handler.go
+++ b/scaffold_source/internal/domains/health/handler.go
@@ -27,6 +27,7 @@ func NewHealthHandler(d healthHandlerDependencies) *HealthHandler {
 }
 
 func (h *HealthHandler) RegisterRoutes(r fiber.Router) {
+	r.Get("/ping", h.Ping)
 	r.Get("/health", h.HealthCheck)
 	r.Get("/health/ready", h.ReadinessCheck)
 }
@@ -75,6 +76,20 @@ func (h *HealthHandler) ReadinessCheck(c *fiber.Ctx) error {
 		})
 	}
 
+	return c.JSON(HealthResponse{
+		Status: "ok",
+	})
+}
+
+// @Summary      Ping
+// @Description  Tests connectivity by pinging the application, requires authentication to verify caller identity
+// @Tags         health
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  HealthResponse
+// @Failure      500  {object}  HealthResponse
+// @Router       /ping [get]
+func (h *HealthHandler) Ping(c *fiber.Ctx) error {
 	return c.JSON(HealthResponse{
 		Status: "ok",
 	})

--- a/scaffold_source/justfile
+++ b/scaffold_source/justfile
@@ -14,6 +14,8 @@ alias sw := swagger
 alias db := docker-build
 alias dr := docker-run
 alias dbr := docker-build-run
+alias gc := generate-creds
+alias rc := regenerate-creds
 
 # Serve the application
 serve:
@@ -56,5 +58,12 @@ docker-run:
 
 docker-build-run: docker-build docker-run
 
+generate-creds:
+    nsc generate creds --name PROJECT_NAME_user --account PROJECT_NAME_account --output-file secrets/PROJECT_NAME_user.creds
+
+regenerate-creds:
+    rm secrets/PROJECT_NAME_user.creds
+    nsc generate creds --name PROJECT_NAME_user --account PROJECT_NAME_account --output-file secrets/PROJECT_NAME_user.creds
+
 migrate-down:
-    go run . migrate down
+    go run . migrate down -c config.yaml

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package gog
 
-const Version = "1.4.0"
+const Version = "1.4.1"


### PR DESCRIPTION
- Update version in version.go to 1.4.1
- Add new commands for generating and regenerating credentials in justfile
- Introduce a new /ping endpoint in health handler for connectivity checks
- Update Swagger documentation to reflect new API changes and improve descriptions
- Modify README and Swagger files for better clarity and consistency