### PR TITLE
feat: enhance API public route handling and add retry utility

### DIFF
--- a/cmd/gog/new/_template/config.yaml.example
+++ b/cmd/gog/new/_template/config.yaml.example
@@ -12,6 +12,10 @@ app:
 
 api:
   key: my-api-key
+  public_routes:
+    - "/api/health"
+    - "/api/health/ready"
+    - "/api/docs"
 
 database:
   host: localhost

--- a/cmd/gog/new/_template/internal/config/config.go
+++ b/cmd/gog/new/_template/internal/config/config.go
@@ -40,7 +40,8 @@ type (
 	}
 
 	Api struct {
-		Key string `mapstructure:"key" validate:"required"`
+		Key          string   `mapstructure:"key" validate:"required"`
+		PublicRoutes []string `mapstructure:"public_routes"`
 	}
 
 	Nats struct {
@@ -87,6 +88,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("database.migrations_dir", "migrations")
 	v.SetDefault("database.driver", "postgres")
 	v.SetDefault("database.migrate_table", "schema_migrations")
+	v.SetDefault("api.public_routes", []string{"/api/health", "/api/health/ready", "/api/docs"})
 
 	var config Config
 	if err := v.Unmarshal(&config); err != nil {

--- a/cmd/gog/new/_template/internal/middleware/auth.go
+++ b/cmd/gog/new/_template/internal/middleware/auth.go
@@ -6,6 +6,7 @@ import (
 	"github.com/PROJECT_NAME/internal/config"
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -48,14 +49,9 @@ func (m *AuthMiddleware) Handle(c *fiber.Ctx) error {
 }
 
 func (m *AuthMiddleware) isPublicRoute(path string) bool {
-	publicPaths := []string{
-		"/api/health",
-		"/api/health/ready",
-		"/api/docs",
-	}
-
-	for _, p := range publicPaths {
-		if strings.HasPrefix(path, p) {
+	path = utils.NormalizePath(path)
+	for _, p := range m.d.Config().Api.PublicRoutes {
+		if path == utils.NormalizePath(p) {
 			return true
 		}
 	}

--- a/cmd/gog/new/_template/internal/middleware/auth_test.go
+++ b/cmd/gog/new/_template/internal/middleware/auth_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/PROJECT_NAME/internal/config"
+	"github.com/PROJECT_NAME/internal/errors"
+	"github.com/PROJECT_NAME/internal/logger"
+)
+
+type mockDependencies struct {
+	c config.Config
+}
+
+func (m *mockDependencies) Config() *config.Config {
+	return &m.c
+}
+
+func (m *mockDependencies) Logger() logger.Logger {
+	return nil
+}
+
+func (m *mockDependencies) NewError(err errors.ErrorCode, message string) *errors.AppError {
+	return nil
+}
+
+func TestIsPublicRoute(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		publicRoutes []string
+		expected     bool
+	}{
+		{
+			name:         "exact match should return true",
+			path:         "/api/health",
+			publicRoutes: []string{"/api/health", "/api/docs"},
+			expected:     true,
+		},
+		{
+			name:         "non-matching path should return false",
+			path:         "/api/private",
+			publicRoutes: []string{"/api/health", "/api/docs"},
+			expected:     false,
+		},
+		{
+			name:         "empty public routes should return false",
+			path:         "/api/health",
+			publicRoutes: []string{},
+			expected:     false,
+		},
+		{
+			name:         "trailing slashes should not affect matching",
+			path:         "/api/health/",
+			publicRoutes: []string{"/api/health"},
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		authMiddleware := AuthMiddleware{
+			d: &mockDependencies{
+				c: config.Config{
+					Api: config.Api{
+						PublicRoutes: tt.publicRoutes,
+					},
+				},
+			},
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			result := authMiddleware.isPublicRoute(tt.path)
+			if result != tt.expected {
+				t.Errorf("TestIsPublicRoute(%s, %v) = %v; want %v",
+					tt.path, tt.publicRoutes, result, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/gog/new/_template/internal/nats/service.go
+++ b/cmd/gog/new/_template/internal/nats/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PROJECT_NAME/internal/config"
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -30,7 +30,7 @@ type (
 		config.ConfigProvider
 		logger.LoggerProvider
 		errors.ErrorProvider
-		retry.RetryProvider
+		utils.RetryProvider
 	}
 
 	svc struct {

--- a/cmd/gog/new/_template/internal/registry/registry.go
+++ b/cmd/gog/new/_template/internal/registry/registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/PROJECT_NAME/internal/logger"
 	"github.com/PROJECT_NAME/internal/middleware"
 	"github.com/PROJECT_NAME/internal/nats"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -25,7 +25,7 @@ type Registry struct {
 	// errors
 	errorHandler *errors.Handler
 
-	retry *retry.Retry
+	retry *utils.Retry
 
 	natsService         nats.Service
 	consumerNameBuilder *nats.ConsumerNameBuilder
@@ -96,7 +96,7 @@ func (r *Registry) RegisterPreMiddlewares(app *fiber.App) {
 	// Global middlewares apply to all routes
 	app.Use(middleware.NewRequestIDMiddleware().Handle)
 	app.Use(middleware.NewLoggingMiddleware(r).Handle)
-	// app.Use(middleware.NewAuthMiddleware(r).Handle)
+	app.Use(middleware.NewAuthMiddleware(r).Handle)
 	// register other middlewares
 }
 

--- a/cmd/gog/new/_template/internal/registry/registry_provider.go
+++ b/cmd/gog/new/_template/internal/registry/registry_provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
 	"github.com/PROJECT_NAME/internal/nats"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 )
 
 type RegistryProvider interface {
@@ -23,7 +23,7 @@ type RegistryProvider interface {
 	nats.ServiceProvider
 	nats.ConsumerNameBuilderProvider
 
-	retry.RetryProvider
+	utils.RetryProvider
 
 	// domains
 	// user
@@ -66,9 +66,9 @@ func (r *Registry) ErrorHandler() *errors.Handler {
 	return r.errorHandler
 }
 
-func (r *Registry) Retry() *retry.Retry {
+func (r *Registry) Retry() *utils.Retry {
 	if r.retry == nil {
-		r.retry = retry.NewRetry(r)
+		r.retry = utils.NewRetry(r)
 	}
 
 	return r.retry

--- a/cmd/gog/new/_template/internal/utils/retry.go
+++ b/cmd/gog/new/_template/internal/utils/retry.go
@@ -1,4 +1,4 @@
-package retry
+package utils
 
 import (
 	"time"

--- a/cmd/gog/new/_template/internal/utils/retry_test.go
+++ b/cmd/gog/new/_template/internal/utils/retry_test.go
@@ -1,4 +1,4 @@
-package retry
+package utils
 
 import (
 	"errors"

--- a/cmd/gog/new/_template/internal/utils/utils.go
+++ b/cmd/gog/new/_template/internal/utils/utils.go
@@ -1,0 +1,7 @@
+package utils
+
+import "strings"
+
+func NormalizePath(path string) string {
+	return strings.Trim(path, "/")
+}

--- a/cmd/gog/new/_template/internal/utils/utils_test.go
+++ b/cmd/gog/new/_template/internal/utils/utils_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import "testing"
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "path with leading slash",
+			path:     "/api/v1/users",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path with trailing slash",
+			path:     "api/v1/users/",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path with leading and trailing slash",
+			path:     "/api/v1/users/",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path without leading slash",
+			path:     "api/v1/users",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "single slash",
+			path:     "/",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizePath(tt.path)
+			if got != tt.expected {
+				t.Errorf("NormalizePath() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/scaffold_source/config.yaml.example
+++ b/scaffold_source/config.yaml.example
@@ -12,6 +12,10 @@ app:
 
 api:
   key: my-api-key
+  public_routes:
+    - "/api/health"
+    - "/api/health/ready"
+    - "/api/docs"
 
 database:
   host: localhost

--- a/scaffold_source/internal/config/config.go
+++ b/scaffold_source/internal/config/config.go
@@ -40,7 +40,8 @@ type (
 	}
 
 	Api struct {
-		Key string `mapstructure:"key" validate:"required"`
+		Key          string   `mapstructure:"key" validate:"required"`
+		PublicRoutes []string `mapstructure:"public_routes"`
 	}
 
 	Nats struct {
@@ -87,6 +88,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("database.migrations_dir", "migrations")
 	v.SetDefault("database.driver", "postgres")
 	v.SetDefault("database.migrate_table", "schema_migrations")
+	v.SetDefault("api.public_routes", []string{"/api/health", "/api/health/ready", "/api/docs"})
 
 	var config Config
 	if err := v.Unmarshal(&config); err != nil {

--- a/scaffold_source/internal/middleware/auth.go
+++ b/scaffold_source/internal/middleware/auth.go
@@ -6,6 +6,7 @@ import (
 	"github.com/PROJECT_NAME/internal/config"
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -48,14 +49,9 @@ func (m *AuthMiddleware) Handle(c *fiber.Ctx) error {
 }
 
 func (m *AuthMiddleware) isPublicRoute(path string) bool {
-	publicPaths := []string{
-		"/api/health",
-		"/api/health/ready",
-		"/api/docs",
-	}
-
-	for _, p := range publicPaths {
-		if strings.HasPrefix(path, p) {
+	path = utils.NormalizePath(path)
+	for _, p := range m.d.Config().Api.PublicRoutes {
+		if path == utils.NormalizePath(p) {
 			return true
 		}
 	}

--- a/scaffold_source/internal/middleware/auth_test.go
+++ b/scaffold_source/internal/middleware/auth_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/PROJECT_NAME/internal/config"
+	"github.com/PROJECT_NAME/internal/errors"
+	"github.com/PROJECT_NAME/internal/logger"
+)
+
+type mockDependencies struct {
+	c config.Config
+}
+
+func (m *mockDependencies) Config() *config.Config {
+	return &m.c
+}
+
+func (m *mockDependencies) Logger() logger.Logger {
+	return nil
+}
+
+func (m *mockDependencies) NewError(err errors.ErrorCode, message string) *errors.AppError {
+	return nil
+}
+
+func TestIsPublicRoute(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		publicRoutes []string
+		expected     bool
+	}{
+		{
+			name:         "exact match should return true",
+			path:         "/api/health",
+			publicRoutes: []string{"/api/health", "/api/docs"},
+			expected:     true,
+		},
+		{
+			name:         "non-matching path should return false",
+			path:         "/api/private",
+			publicRoutes: []string{"/api/health", "/api/docs"},
+			expected:     false,
+		},
+		{
+			name:         "empty public routes should return false",
+			path:         "/api/health",
+			publicRoutes: []string{},
+			expected:     false,
+		},
+		{
+			name:         "trailing slashes should not affect matching",
+			path:         "/api/health/",
+			publicRoutes: []string{"/api/health"},
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		authMiddleware := AuthMiddleware{
+			d: &mockDependencies{
+				c: config.Config{
+					Api: config.Api{
+						PublicRoutes: tt.publicRoutes,
+					},
+				},
+			},
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			result := authMiddleware.isPublicRoute(tt.path)
+			if result != tt.expected {
+				t.Errorf("TestIsPublicRoute(%s, %v) = %v; want %v",
+					tt.path, tt.publicRoutes, result, tt.expected)
+			}
+		})
+	}
+}

--- a/scaffold_source/internal/nats/service.go
+++ b/scaffold_source/internal/nats/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PROJECT_NAME/internal/config"
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -30,7 +30,7 @@ type (
 		config.ConfigProvider
 		logger.LoggerProvider
 		errors.ErrorProvider
-		retry.RetryProvider
+		utils.RetryProvider
 	}
 
 	svc struct {

--- a/scaffold_source/internal/registry/registry.go
+++ b/scaffold_source/internal/registry/registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/PROJECT_NAME/internal/logger"
 	"github.com/PROJECT_NAME/internal/middleware"
 	"github.com/PROJECT_NAME/internal/nats"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -25,7 +25,7 @@ type Registry struct {
 	// errors
 	errorHandler *errors.Handler
 
-	retry *retry.Retry
+	retry *utils.Retry
 
 	natsService         nats.Service
 	consumerNameBuilder *nats.ConsumerNameBuilder
@@ -96,7 +96,7 @@ func (r *Registry) RegisterPreMiddlewares(app *fiber.App) {
 	// Global middlewares apply to all routes
 	app.Use(middleware.NewRequestIDMiddleware().Handle)
 	app.Use(middleware.NewLoggingMiddleware(r).Handle)
-	// app.Use(middleware.NewAuthMiddleware(r).Handle)
+	app.Use(middleware.NewAuthMiddleware(r).Handle)
 	// register other middlewares
 }
 

--- a/scaffold_source/internal/registry/registry_provider.go
+++ b/scaffold_source/internal/registry/registry_provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PROJECT_NAME/internal/errors"
 	"github.com/PROJECT_NAME/internal/logger"
 	"github.com/PROJECT_NAME/internal/nats"
-	"github.com/PROJECT_NAME/internal/utils/retry"
+	"github.com/PROJECT_NAME/internal/utils"
 )
 
 type RegistryProvider interface {
@@ -23,7 +23,7 @@ type RegistryProvider interface {
 	nats.ServiceProvider
 	nats.ConsumerNameBuilderProvider
 
-	retry.RetryProvider
+	utils.RetryProvider
 
 	// domains
 	// user
@@ -66,9 +66,9 @@ func (r *Registry) ErrorHandler() *errors.Handler {
 	return r.errorHandler
 }
 
-func (r *Registry) Retry() *retry.Retry {
+func (r *Registry) Retry() *utils.Retry {
 	if r.retry == nil {
-		r.retry = retry.NewRetry(r)
+		r.retry = utils.NewRetry(r)
 	}
 
 	return r.retry

--- a/scaffold_source/internal/utils/retry.go
+++ b/scaffold_source/internal/utils/retry.go
@@ -1,4 +1,4 @@
-package retry
+package utils
 
 import (
 	"time"

--- a/scaffold_source/internal/utils/retry_test.go
+++ b/scaffold_source/internal/utils/retry_test.go
@@ -1,4 +1,4 @@
-package retry
+package utils
 
 import (
 	"errors"

--- a/scaffold_source/internal/utils/utils.go
+++ b/scaffold_source/internal/utils/utils.go
@@ -1,0 +1,7 @@
+package utils
+
+import "strings"
+
+func NormalizePath(path string) string {
+	return strings.Trim(path, "/")
+}

--- a/scaffold_source/internal/utils/utils_test.go
+++ b/scaffold_source/internal/utils/utils_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import "testing"
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "path with leading slash",
+			path:     "/api/v1/users",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path with trailing slash",
+			path:     "api/v1/users/",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path with leading and trailing slash",
+			path:     "/api/v1/users/",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "path without leading slash",
+			path:     "api/v1/users",
+			expected: "api/v1/users",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "single slash",
+			path:     "/",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizePath(tt.path)
+			if got != tt.expected {
+				t.Errorf("NormalizePath() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package gog
 
-const Version = "1.4.4"
+const Version = "1.4.5"


### PR DESCRIPTION
- Introduced public routes configuration in `config.yaml.example` and updated the `Api` struct in `config.go` to support public routes.
- Implemented `isPublicRoute` method in `auth.go` to check if a route is public based on the new configuration.
- Added a new `utils` package with a `Retry` utility for handling retry logic in operations, including tests for various scenarios.
- Refactored middleware and registry to utilize the new `utils` package for retry functionality.
- Added unit tests for public route validation and retry logic to ensure robustness.